### PR TITLE
[Nginx] Increases nginx client body size to 1G

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -35,6 +35,7 @@ http {
     server {
         listen 80;
         charset utf-8;
+        client_max_body_size 1024m;
 
         add_header X-Frame-Options DENY;
         add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
## What?

This PR increases nginx client body size to `1024m` to allow longer audio files.