### PR TITLE
Annotation upload added

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -284,6 +284,12 @@ class Segmentation(db.Model):
         single_parent=True,
     )
 
+    def set_start_time(self, start_time):
+        self.start_time = start_time
+
+    def set_end_time(self, end_time):
+        self.end_time = end_time
+
     def set_transcription(self, transcription):
         self.transcription = transcription
 

--- a/backend/routes/data.py
+++ b/backend/routes/data.py
@@ -26,7 +26,7 @@ def send_audio_file(file_name):
 def validate_segmentation(segment):
     """Validate the segmentation before accepting the annotation's upload from users
     """
-    required_key = {"annotations", "end_time", "created_at", "transcription"}
+    required_key = {"annotations", "end_time", "transcription"}
 
     if set(required_key).issubset(segment.keys()):
         return True
@@ -122,6 +122,17 @@ def add_data():
         annotations = []
         for segment in segmentations:
             validated = validate_segmentation(segment)
+
+            if not validated:
+                app.logger.error(f"Error adding segmentation: {segment}")
+                return (
+                    jsonify(
+                        message=f"Error adding data to project: {project.name}",
+                        type="DATA_CREATION_FAILED",
+                    ),
+                    400,
+                )
+
             annotations.append(generate_segmentation(
                 data_id=None,
                 end_time=segment['end_time'],
@@ -129,9 +140,6 @@ def add_data():
                 annotations=segment['annotations'],
                 transcription=segment['transcription'],
             ))
-            if not validated:
-                app.logger.error(f"Error adding segmentation: {segment}")
-                app.logger.error(f"Skipping the data point")
 
         data = Data(
             project_id=project.id,

--- a/backend/routes/projects.py
+++ b/backend/routes/projects.py
@@ -567,6 +567,7 @@ def add_segmentations(project_id, data_id, segmentation_id=None):
 
         segmentation = generate_segmentation(
             data_id=data_id,
+            project_id=project.id,
             end_time=end_time,
             start_time=start_time,
             annotations=annotations,

--- a/docs/tutorials/upload-data.md
+++ b/docs/tutorials/upload-data.md
@@ -1,6 +1,6 @@
 ## Upload datapoints
 
-The tool provides an end point to upload datapoints. You would need an API Key which can be found on the admin dashboard for all projects. To upload datapoints for a project, you would need to make a `POST` request to `/api/data` end point. API Key should be passed in `Authorization` header.
+The tool provides an end point to upload datapoints. You would need an API Key which can be found on the admin dashboard for all projects. To upload datapoints for a project, you would need to make a `POST` request to `/api/data` end point. API Key should be passed in `Authorization` header. Labels for data can also be uploaded.
 
 For every datapoint, we need to provide the following required information:
 
@@ -11,11 +11,20 @@ You can also provide the following optional information:
 
 1. `reference_transcription`: Transcription of audio for reference.
 2. `is_marked_for_review`:  Whether this audio should be marked for review or not.
+3. `segmentations` : The list of segmentation values for the given audio.
 
 We provide an [example CLI script](../../examples/upload_data/upload_data.py) to show how to upload the datapoints.
 
-For example,
+For example, you can add data with reference transcripts
 
 ```sh
 API_KEY=4369e45d3a94466b8fe1efb86b8a4392 python upload_data.py  --username admin --is_marked_for_review True --audio_file OSR_us_000_0010_8k.wav --host localhost --port 80 --reference_transcription "The birch canoe slid on the smooth planks. Glue the sheet to the dark blue background. It's easy to tell the depth of a well. These days a chicken leg is a rare dish. Rice is often served in round bowls. The juice of lemons makes fine punch. The box was thrown beside the parked truck. The hogs were fed chopped corn and garbage. Four hours of steady work faced us. Large size in stockings is hard to sell."
+```
+
+or
+
+add data with segmentation values
+
+```sh
+API_KEY=4369e45d3a94466b8fe1efb86b8a4392 python upload_data.py  --username admin --is_marked_for_review True --audio_file OSR_us_000_0010_8k.wav --host localhost --port 80 --segmentations '''[{"annotations": {},"end_time": 7.7407,"start_time": 3.8604,"transcription": "Sample transcription data"}]'''
 ```

--- a/examples/upload_data/upload_data.py
+++ b/examples/upload_data/upload_data.py
@@ -33,6 +33,12 @@ parser.add_argument(
     help="Whether datapoint should be marked for review",
     default=False,
 )
+parser.add_argument(
+    "--segmentations",
+    type=str,
+    help="List of segmentations for the audio",
+    default=[],
+)
 parser.add_argument("--port", type=int, help="Port to make request to", default=80)
 
 args = parser.parse_args()
@@ -51,15 +57,16 @@ else:
 reference_transcription = args.reference_transcription
 username = args.username
 is_marked_for_review = args.is_marked_for_review
+segmentations = args.segmentations
 
 file = {"audio_file": (audio_filename, audio_obj)}
 
 values = {
     "reference_transcription": reference_transcription,
     "username": username,
+    "segmentations": segmentations,
     "is_marked_for_review": is_marked_for_review,
 }
-
 print("Creating datapoint")
 response = requests.post(
     f"http://{args.host}:{args.port}/api/data", files=file, data=values, headers=headers

--- a/frontend/src/pages/labelValues.js
+++ b/frontend/src/pages/labelValues.js
@@ -125,6 +125,7 @@ class LabelValues extends React.Component {
                   <thead>
                     <tr>
                       <th scope="col">#</th>
+                      <th scope="col">LabelValueId</th>
                       <th scope="col">Value</th>
                       <th scope="col">Created On</th>
                       <th scope="col">Options</th>
@@ -137,6 +138,9 @@ class LabelValues extends React.Component {
                           <th scope="row" className="align-middle">
                             {index + 1}
                           </th>
+                          <td className="align-middle">
+                            {labelValue["value_id"]}
+                          </td>
                           <td className="align-middle">
                             {labelValue["value"]}
                           </td>

--- a/frontend/src/pages/labels.js
+++ b/frontend/src/pages/labels.js
@@ -133,6 +133,7 @@ class Labels extends React.Component {
                   <thead>
                     <tr>
                       <th scope="col">#</th>
+                      <th scope="col">LabelId</th>
                       <th scope="col">Name</th>
                       <th scope="col">Type</th>
                       <th scope="col">Created On</th>
@@ -146,6 +147,7 @@ class Labels extends React.Component {
                           <th scope="row" className="align-middle">
                             {index + 1}
                           </th>
+                          <td className="align-middle">{label["label_id"]}</td>
                           <td className="align-middle">{label["name"]}</td>
                           <td className="align-middle">{label["type"]}</td>
                           <td className="align-middle">


### PR DESCRIPTION
Users can now upload annotations for data if they already have them. 
If an annotation is uploaded and it is valid, the annotation is added into the DB. If the annotation is not valid: `exception` is thrown and the datapoints is skipped .
if there is no annotation to upload: the addition process is skipped.
```python

values = {
    "reference_transcription": reference_transcription,
    "username": username,
    "segmentations": json.dumps([{
                "annotations": {},
                "end_time": 7.7407,
                "start_time": 3.8604,
                "transcription": "asdasdasdas",
     }]),
    "is_marked_for_review": is_marked_for_review,
}
print("Creating datapoint")
response = requests.post(
    f"http://{args.host}:{args.port}/api/data", files=file, data=values, headers=headers
)
```

or pass the segmentations via cli:
```bash
API_KEY=4369e45d3a94466b8fe1efb86b8a4392 python upload_data.py  --username admin --is_marked_for_review True --audio_file OSR_us_000_0010_8k.wav --host localhost --port 80 --segmentations '''[{"annotations": {},"end_time": 7.7407,"start_time": 3.8604,"transcription": "Sample transcription data"}]'''
```