### PR TITLE
[Fix #62] Upgrades flask-jwt-extended to 3.25.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,5 +17,5 @@ SQLAlchemy==1.3.9
 uWSGI==2.0.18
 Werkzeug==0.16.0
 WTForms==2.2.1
-flask-jwt-extended==3.24.1
+flask-jwt-extended==3.25
 flask-redis==0.4.0

--- a/backend/routes/login.py
+++ b/backend/routes/login.py
@@ -15,7 +15,7 @@ from . import auth
 
 
 @jwt.token_in_blacklist_loader
-def check_if_token_is_revoked(decrypted_token):
+def revoked_token_callback(decrypted_token):
     jti = decrypted_token["jti"]
     entry = redis_client.get(jti)
 
@@ -26,8 +26,13 @@ def check_if_token_is_revoked(decrypted_token):
 
 
 @jwt.expired_token_loader
-def my_expired_token_callback(expired_token):
+def expired_token_callback(expired_token):
     return jsonify(message="JWT has expired!", type="JWT_EXPIRED"), 401
+
+
+@jwt.invalid_token_loader
+def tampered_token_callback(expired_token):
+    return jsonify(message="JWT is tampered!", type="JWT_TAMPERED"), 401
 
 
 @auth.route("/login", methods=["POST"])


### PR DESCRIPTION
## What?

This PR upgrades `flask-jwt-extended` from `3.24.1` to `3.25.0` and fixes #62.

cc @jmikedupont2 